### PR TITLE
Added Khan Academy, r/electronics, changed "tutorials"

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,6 @@ Also check out the [PCB/EDA software list](http://www.eevblog.com/forum/eda/pcbe
 
 ### Help
  - [/r/askelectronics](https://reddit.com/r/askelectronics) - Sub-reddit dedicated to help on electronics topics.
- - [/r/electronics](https://www.reddit.com/r/electronics/) - Sub-reddit dedicated to news, articles and general discussions related to the field of electronic systems and circuits.
  - [Electronics Stack Exchange](https://electronics.stackexchange.com) - Question and answer site for electronics running on the popular Stack Overflow service.
  - [EEVBlog beginners forum](http://www.eevblog.com/forum/beginners/) - Good place for beginner questions, other sub-forums on EEVblog should be suitable for questions on more advanced topics.
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Also check out the [PCB/EDA software list](http://www.eevblog.com/forum/eda/pcbe
 - [Podcasts](#podcasts)
 - [Videos](#videos)
 - [Tutorials](#tutorials)
+- [Learning](#learning)
+  * [Technical Tutorials](#technical-tutorials)
+  * [Theory and Courses](#theory-and-courses)
 
 <!-- tocstop -->
 
@@ -123,6 +126,7 @@ Also check out the [PCB/EDA software list](http://www.eevblog.com/forum/eda/pcbe
 
 ### Help
  - [/r/askelectronics](https://reddit.com/r/askelectronics) - Sub-reddit dedicated to help on electronics topics.
+ - [/r/electronics](https://www.reddit.com/r/electronics/) - Sub-reddit dedicated to news, articles and general discussions related to the field of electronic systems and circuits.
  - [Electronics Stack Exchange](https://electronics.stackexchange.com) - Question and answer site for electronics running on the popular Stack Overflow service.
  - [EEVBlog beginners forum](http://www.eevblog.com/forum/beginners/) - Good place for beginner questions, other sub-forums on EEVblog should be suitable for questions on more advanced topics.
 
@@ -148,7 +152,12 @@ Also check out the [PCB/EDA software list](http://www.eevblog.com/forum/eda/pcbe
 - [MikesElectricStuff](https://www.youtube.com/channel/UCcs0ZkP_as4PpHDhFcmCHyA) - Teardowns, large lighting projects, xrays and more.
 - [Ben Eater](https://www.youtube.com/playlist?list=PLowKtXNTBypGqImE405J2565dvjafglHU) - Series of videos on building an 8-bit computer on breadboards with excellent explanations of all the sub-circuits.
 
-## Tutorials
-- [All About Circuits](http://www.allaboutcircuits.com/textbook/) - Online textbook for learning theory with clear diagrams and explanations.
+## Learning
+
+### Technical Tutorials
 - [Soldering is Easy](http://mightyohm.com/blog/2011/04/soldering-is-easy-comic-book/) - Comic book that goes over the basics of soldering that has been translated into quite a few languages.
 - [Uses of Different Soldering Iron Tips](http://www.instructables.com/id/Uses-of-Different-Soldering-Iron-Tips/?ALLSTEPS) - Covers what all those different soldering iron tips are good for.
+
+### Theory and Courses
+- [All About Circuits](http://www.allaboutcircuits.com/textbook/) - Online textbook for learning theory with clear diagrams and explanations.
+- [Electrical Engineering - Khan Academy](https://www.khanacademy.org/science/electrical-engineering) - Online learning platform with lots of topics, including a full course on electrical engineering, circuits, semiconductors, signals, robots, and even reverse engineering electronic devices.


### PR DESCRIPTION
I have added the r/electronics sub-reddit which may be useful for hobbyists, and getting inspiration for electronic projects.
I have added Khan Academy, and propose a category change for tutorials.

There should be a difference between technical tutorials focused in "how-to" and resources containing theory, similar to university lessons.
Where, for example, soldering is a "how-to", and learning about circuits or semiconductors is more a matter of theory.
"How-to"s are useful for DIY projects and experiments, while theory is useful for university students, as additional studying material.